### PR TITLE
Don't use absolute command paths on Unix

### DIFF
--- a/src/experimental_limit.rs
+++ b/src/experimental_limit.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 #[cfg(not(windows))]
 fn get_echo_command() -> Command {
-    Command::new("/bin/echo")
+    Command::new("echo")
 }
 
 #[cfg(windows)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! # {
 //! use argmax::Command;
 //!
-//! let mut cmd = Command::new("/bin/echo");
+//! let mut cmd = Command::new("echo");
 //!
 //! // Add as many arguments as possible
 //! while cmd.try_arg("foo").is_ok() {}

--- a/src/unix.rs
+++ b/src/unix.rs
@@ -106,11 +106,10 @@ mod tests {
         println!("Experimental limit: {}", experimental_limit);
 
         let arg_size = 8 + 3 + 1;
-        let experimental_size_limit =
-            experimental_limit * arg_size + 8 + 1 + "/bin/echo".len() as i64;
+        let experimental_size_limit = experimental_limit * arg_size + 8 + 1 + "echo".len() as i64;
 
         assert!(
-            available_argument_length([OsStr::new("/bin/echo")].iter()).unwrap_or(0)
+            available_argument_length([OsStr::new("echo")].iter()).unwrap_or(0)
                 <= experimental_size_limit
         );
     }

--- a/tests/main.rs
+++ b/tests/main.rs
@@ -4,7 +4,7 @@ use argmax::Command;
 
 #[cfg(not(windows))]
 fn get_echo_command() -> Command {
-    Command::new("/bin/echo")
+    Command::new("echo")
 }
 
 #[cfg(windows)]


### PR DESCRIPTION
Some Unix systems (e.g. Nix, GNU Guix) do not keep binaries other than
sh in `/bin`. While assuming the echo command is present is ok, it should
be taken from the user's path.