### PR TITLE
Implement Deref to be able to use std::process:Command methods

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,6 +155,10 @@ impl Command {
     pub fn status(&mut self) -> io::Result<ExitStatus> {
         self.inner.status()
     }
+
+    pub fn get_program(&self) -> &OsStr {
+        self.inner.get_program()
+    }
 }
 
 #[cfg(test)]
@@ -188,5 +192,7 @@ mod tests {
 
         let status = cmd.status().expect("status() to succeed");
         assert!(status.success());
+
+        assert_eq!(cmd.get_program(), "echo");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,7 @@
 
 use std::ffi::OsStr;
 use std::io;
+use std::ops::Deref;
 use std::path::Path;
 use std::process::{self, Child, ExitStatus, Output, Stdio};
 
@@ -155,9 +156,13 @@ impl Command {
     pub fn status(&mut self) -> io::Result<ExitStatus> {
         self.inner.status()
     }
+}
 
-    pub fn get_program(&self) -> &OsStr {
-        self.inner.get_program()
+impl Deref for Command {
+    type Target = process::Command;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
     }
 }
 
@@ -192,7 +197,5 @@ mod tests {
 
         let status = cmd.status().expect("status() to succeed");
         assert!(status.success());
-
-        assert_eq!(cmd.get_program(), "echo");
     }
 }


### PR DESCRIPTION
I find this useful in std::process:Command. Useful for possible solutions to something like (writing custom formatting methods for it):
https://github.com/sharkdp/fd/issues/1083

...and off course other places where argmax is used and we want to print the program name for whatever reason. It will include the entire path given to std::process:Command::new.

Feel free to ignore/close if this is something that has already been considered, or if you just think it is stupid  🙂 