### PR TITLE
Adjust maximum argument length for illumos

### DIFF
--- a/src/unix.rs
+++ b/src/unix.rs
@@ -62,6 +62,13 @@ pub(crate) fn available_argument_length<O: AsRef<OsStr>>(
         arg_max = UPPER_BOUND_COMMAND_LINE_LENGTH;
     }
 
+    if cfg!(all(target_os = "illumos", target_pointer_width = "64")) {
+        // When a 64-bit rust retrieves ARG_MAX, it will get the value that
+        // applies to 64-bit binaries which is twice that allowed for 32-bit.
+        // Since we may well be exec()ing a 32-bit binary, reduce the limit.
+        arg_max /= 2;
+    }
+
     // We have to share space with the environment variables
     arg_max -= size_of_environment();
     // Account for the terminating NULL entry


### PR DESCRIPTION
While using `rustfd`'s `-X` option on an illumos system with a long list of files, I see:

```
% fd -t f . proto -X strings -a  | grep ':.*amd64' | sort
[fd error]: Problem while executing command: Arg list too long (os error 7)
```

This turns out to be because `strings` is a 32-bit program, which has a lower argument length limit than a 64-bit one.

Running this crate's tests on illumos fails:

```
test unix::tests::available_argument_length_is_smaller_than_experimental_limit ... FAILED

failures:

---- unix::tests::available_argument_length_is_smaller_than_experimental_limit stdout ----
Experimental limit: 1570369
thread 'unix::tests::available_argument_length_is_smaller_than_experimental_limit' panicked at 'assertion failed: available_argument_length([OsStr::new(\"echo\")].iter()).unwrap_or(0) <=\n    experimental_size_limit', src/unix.rs:110:9
```

sysconfig(ARG_MAX) is 2096640 for a 64-bit process and 1048320 for 32-bit.
Also defined in `<limits.h>`
```
#define _ARG_MAX32      1048320 /* max length of args to exec 32-bit program */
#define _ARG_MAX64      2096640 /* max length of args to exec 64-bit program */
```

The experimental limit using `/usr/bin/echo` (32-bit) is 1570369
The experimental limit using `/usr/bin/amd64/echo` (64-bit) is 2095129

I do not know a good way to retrieve the 32-bit value from the 64-bit rust process, but halving seems like a reasonable workaround.

With this fix, all crate tests pass (and rustfd patched to use this branch also works).

