### PR TITLE
Update nix dependency to 0.29

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ edition = "2018"
 authors = ["David Peter <mail@david-peter.de>"]
 
 [dependencies]
-nix = { version = "0.25.0", default-features = false, features = ["feature"] }
+nix = { version = "0.29.0", default-features = false, features = ["feature"] }
 once_cell = "1.17"
 
 [target.'cfg(unix)'.dependencies]


### PR DESCRIPTION
This crate only uses the `sysconf` API,

https://github.com/sharkdp/argmax/blob/c1c35aa8757fe117d709a11ffe00d6940b5c0138/src/unix.rs#L9

and no incompatible changes to it are recorded in https://github.com/nix-rust/nix/blob/v0.29.0/CHANGELOG.md#0290---2024-05-24.

Furthermore, `cargo test` still passes (on Fedora 42).